### PR TITLE
Exporting update

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -4,6 +4,8 @@ archivalPathOther=/home/mfcs.lib.wvu.edu/data/archives/other
 archivalPathStaging=/home/mfcs.lib.wvu.edu/data/working/mfcsStaging
 convertedPath=/home/mfcs.lib.wvu.edu/data/exports
 mfcstmp=/home/mfcs.lib.wvu.edu/data/working/tmp
+nfsexport=/home/mfcs.lib.wvu.edu/data/nfs-exports/mfcs-exports
+exportControlTemplate=/home/mfcs.lib.wvu.edu/public_html/includes/templates/export_control_file.yaml
 
 siteRoot=/
 pageTitle=Metadata Form Creation System

--- a/public_html/includes/classes/exporting.php
+++ b/public_html/includes/classes/exporting.php
@@ -138,6 +138,20 @@ class exporting {
 		return $template;
 	}
 
+	public static function setExportDate($form,$timestamp) {
+		$sql       = sprintf("INSERT INTO `exports` (`formID`,`date`) VALUES('%s','%s')",
+			mfcs::$engine->openDB->escape($form_id),
+			mfcs::$engine->openDB->escape($timestamp)
+		);
+		$sqlResult = $engine->openDB->query($sql);
+
+		if (!$sqlResult['result']) {
+			errorHandle::newError(__METHOD__."() - : ".$sqlResult['error'], errorHandle::DEBUG);
+			return false;
+		}
+		return true;
+	}
+
 }
 
 ?>

--- a/public_html/includes/classes/exporting.php
+++ b/public_html/includes/classes/exporting.php
@@ -138,12 +138,12 @@ class exporting {
 		return $template;
 	}
 
-	public static function setExportDate($form,$timestamp) {
+	public static function setExportDate($form_id,$timestamp) {
 		$sql       = sprintf("INSERT INTO `exports` (`formID`,`date`) VALUES('%s','%s')",
 			mfcs::$engine->openDB->escape($form_id),
 			mfcs::$engine->openDB->escape($timestamp)
 		);
-		$sqlResult = $engine->openDB->query($sql);
+		$sqlResult = mfcs::$engine->openDB->query($sql);
 
 		if (!$sqlResult['result']) {
 			errorHandle::newError(__METHOD__."() - : ".$sqlResult['error'], errorHandle::DEBUG);

--- a/public_html/includes/classes/exporting.php
+++ b/public_html/includes/classes/exporting.php
@@ -139,10 +139,16 @@ class exporting {
 		}
 
 		foreach ($export_directories as $export_directory) {
-				if (!mkdir(sprintf("%s/%s",$directories["filesExportBaseDir"],$export_directory))) {
-					errorHandle::newError(__METHOD__."() - Error creating ".$export_directory, errorHandle::DEBUG);
-					return false;
-				}
+			if (array_key_exists($export_directory, $directories)) {
+				errorHandle::newError(__METHOD__."() - duplicate directory: ".$export_directory, errorHandle::DEBUG);
+				return false;
+			}
+			
+			$directories[$export_directory] = sprintf("%s/%s",$directories["filesExportBaseDir"],$export_directory);
+			if (!mkdir($directories[$export_directory])) {
+				errorHandle::newError(__METHOD__."() - Error creating: ".$directories[$export_directory], errorHandle::DEBUG);
+				return false;
+			}
 		}
 
 		return $directories;
@@ -191,7 +197,7 @@ class exporting {
 	public static function getExportDate($form_id) {
 		$sql       = sprintf("SELECT MAX(`date`) FROM exports WHERE `formID`='%s'",
 		mfcs::$engine->openDB->escape($form_id));
-		$sqlResult = $engine->openDB->query($sql);
+		$sqlResult = mfcs::$engine->openDB->query($sql);
 
 		if (!$sqlResult['result']) {
 			errorHandle::newError(__METHOD__."() - : ".$sqlResult['error'], errorHandle::DEBUG);

--- a/public_html/includes/classes/exporting.php
+++ b/public_html/includes/classes/exporting.php
@@ -134,7 +134,7 @@ class exporting {
 
 		$directories["filesExportBaseDir"] = sprintf("%s/%s",$directories["export_base_dir"],$time_stamp);
 		if (!mkdir($directories["filesExportBaseDir"])) {
-			errorHandle::newError(__METHOD__."() - export base.", errorHandle::DEBUG);
+			errorHandle::newError(__METHOD__."() - export base: ".$directories["filesExportBaseDir"], errorHandle::DEBUG);
 			return false;
 		}
 

--- a/public_html/includes/classes/exporting.php
+++ b/public_html/includes/classes/exporting.php
@@ -123,6 +123,21 @@ class exporting {
 
 	}
 
+	public static function generateControlFile($project_name, $timestamp, $export_type, $digital_items_count, $record_count) {
+		if (($template = file_get_contents(mfcs::config("exportControlTemplate"))) === FALSE) {
+			print "Error opening Export Control Template.";
+			exit;
+		}
+
+		$template = preg_replace("/{{ project_name }}/", $project_name, $template);
+		$template = preg_replace("/{{ timestamp }}/", $timestamp, $template);
+		$template = preg_replace("/{{ export_type }}/", $export_type, $template);
+		$template = preg_replace("/{{ digital_items_count }}/", $digital_items_count, $template);
+		$template = preg_replace("/{{ record_count }}/",$record_count, $template);
+
+		return $template;
+	}
+
 }
 
 ?>

--- a/public_html/includes/classes/exporting.php
+++ b/public_html/includes/classes/exporting.php
@@ -127,7 +127,7 @@ class exporting {
 
 		$directories = array();
 
-		$directories["base_dir"] = sprintf("%s/%s",$project_name,$export_path);
+		$directories["base_dir"] = sprintf("%s/%s",$export_path,$project_name);
 		$directories["export_base_dir"] = sprintf("%s/export",$directories["base_dir"]);
 		$directories["control_dir"] = sprintf("%s/control/mfcs",$directories["base_dir"]);
 		$directories["export_control_file"] = sprintf("%s/%s.yaml",$directories["control_dir"],$time_stamp);

--- a/public_html/includes/templates/export_control_file.yaml
+++ b/public_html/includes/templates/export_control_file.yaml
@@ -1,0 +1,12 @@
+---
+  project_name: {{ project_name }}
+  time_stamp: {{ timestamp }}
+  # Export Type can be
+  # 1. update : metadata for all objects, but not all digital items
+  # 1. update_full : both metadata and digital items for all objects
+  # 1. full : Same as update_full, but we assume that there is no data loaded
+  #           This would be for an intial load
+  # 1. partial : metadata update for some items and/or some digital objects
+  export_type: {{ export_type }}
+  digital_items_count: {{ digital_items_count }}
+  record_count: {{ record_count }}


### PR DESCRIPTION
Exporting updates to support auto loading into an external system. 

It is possible that some external systems may need additional information in the control file. However, it should be trivial to add additional control files. Some code will need to be changed. It may be needed to setup an map of replacements for control files. This situation should be addressed IF it ever becomes a concern. 