### PR TITLE
Add Public Export and OAI form metadata options

### DIFF
--- a/SQLFiles/migrations/2016.12.10.1710.sql
+++ b/SQLFiles/migrations/2016.12.10.1710.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `forms`
+  ADD COLUMN `exportPublic` tinyint(4) NOT NULL DEFAULT 0 AFTER  `metadata`,
+  ADD COLUMN `exportOAI` tinyint(4) NOT NULL DEFAULT 0 AFTER  `exportPublic`;

--- a/public_html/formCreator/index.php
+++ b/public_html/formCreator/index.php
@@ -127,6 +127,8 @@ if (isset($engine->cleanPost['MYSQL']['submitForm'])) {
 							`container`='%s',
 							`production`='%s',
 							`metadata`='%s',
+							`exportPublic`='%s',
+							`exportOAI`='%s',
 							%s
 							`displayTitle`='%s',
 							`objectTitleField`='%s',
@@ -141,6 +143,8 @@ if (isset($engine->cleanPost['MYSQL']['submitForm'])) {
 			$engine->openDB->escape($form['formContainer']),      // container=
 			$engine->openDB->escape($form['formProduction']),     // production=
 			$engine->openDB->escape($form['formMetadata']),       // metadata=
+			$engine->openDB->escape($form['exportPublic']),
+			$engine->openDB->escape($form['exportOAI']),
 			$countSql,                                            // count=
 			(is_empty($engine->openDB->escape($form['objectDisplayTitle'])) ? $engine->openDB->escape($form['formTitle']) : $engine->openDB->escape($form['objectDisplayTitle'])),
 			// displayTitle
@@ -157,7 +161,7 @@ if (isset($engine->cleanPost['MYSQL']['submitForm'])) {
 	}
 	else {
 		// Insert into forms table
-		$sql = sprintf("INSERT INTO `forms` (title, description, fields, idno, submitButton, updateButton, container, production, metadata, count, displayTitle, objectTitleField, linkTitle) VALUES ('%s',%s,'%s','%s','%s','%s','%s','%s','%s','%s','%s','%s',%s)",
+		$sql = sprintf("INSERT INTO `forms` (title, description, fields, idno, submitButton, updateButton, container, production, metadata, exportPublic, exportOAI, count, displayTitle, objectTitleField, linkTitle) VALUES ('%s',%s,'%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s',%s)",
 			$engine->openDB->escape($form['formTitle']),
 			isset($form['formDescription']) ? "'".$engine->openDB->escape($form['formDescription'])."'" : "NULL",
 			encodeFields($fields),
@@ -167,6 +171,8 @@ if (isset($engine->cleanPost['MYSQL']['submitForm'])) {
 			$engine->openDB->escape($form['formContainer']),
 			$engine->openDB->escape($form['formProduction']),
 			$engine->openDB->escape($form['formMetadata']),
+			$engine->openDB->escape($form['exportPublic']),
+			$engine->openDB->escape($form['exportOAI']),
 			$engine->openDB->escape($count),
 			(is_empty($engine->openDB->escape($form['objectDisplayTitle'])) ? $engine->openDB->escape($form['formTitle']) : $engine->openDB->escape($form['objectDisplayTitle'])),
 			$engine->openDB->escape($form['objectTitleField']),
@@ -353,6 +359,8 @@ if (!isnull($formID) && $formCreationError === FALSE) {
 		localVars::add("formContainer",   ($form['container'] == '1')  ? "checked" : "");
 		localVars::add("formProduction",  ($form['production'] == '1') ? "checked" : "");
 		localVars::add("formMetadata",    ($form['metadata'] == '1')   ? "checked" : "");
+		localVars::add("exportPublic",    ($form['exportPublic'] == '1')   ? "checked" : "");
+		localVars::add("exportOAI",       ($form['exportOAI'] == '1')   ? "checked" : "");
 
 		if (is_empty($form['fields'])) {
 			$form['fields'] = array();
@@ -463,6 +471,8 @@ else if($formCreationError === TRUE){
 		localVars::add("formContainer",   ($form['formContainer'] == '1')  ? "checked" : "");
 		localVars::add("formProduction",  ($form['formProduction'] == '1') ? "checked" : "");
 		localVars::add("formMetadata",    ($form['formMetadata'] == '1')   ? "checked" : "");
+		localVars::add("exportPublic",    ($form['exportPublic'] == '1')   ? "checked" : "");
+		localVars::add("exportOAI",       ($form['exportOAI'] == '1')   ? "checked" : "");
 
 		if (is_empty($form['fields'])) {
 			$form['fields'] = array();

--- a/public_html/formCreator/templates/formPreview.php
+++ b/public_html/formCreator/templates/formPreview.php
@@ -144,6 +144,8 @@
                                     <li><label class="checkbox" for="formSettings_formContainer"><input type="checkbox" id="formSettings_formContainer" name="formSettings_formContainer" {local var="formContainer"}> Act as Container</label></li>
                                     <li><label class="checkbox" for="formSettings_formProduction"><input type="checkbox" id="formSettings_formProduction" name="formSettings_formProduction" {local var="formProduction"}> Production Ready</label></li>
                                     <li><label class="checkbox" for="formSettings_formMetadata"><input type="checkbox" id="formSettings_formMetadata" name="formSettings_formMetadata" {local var="formMetadata"}> Metadata Form</label></li>
+                                    <li><label class="checkbox" for="formSettings_exportPublic"><input type="checkbox" id="formSettings_exportPublic" name="formSettings_exportPublic" {local var="exportPublic"}> Export To Public</label></li>
+                                    <li><label class="checkbox" for="formSettings_exportOAI"><input type="checkbox" id="formSettings_exportOAI" name="formSettings_exportOAI" {local var="exportOAI"}> OAI-PMH Export</label></li>
                                 </ul>
                                 <span class="help-block hidden"></span>
                             </div>


### PR DESCRIPTION
Add two new options to the form to designate as exporting to public, and designate the form as OAI. These are required to properly export metadata to the OAI server. Otherwise we do not know if 1) a form is ready for release to the public, and 2) if a form is supposed to be indexed in the OAI server for ppublic harvisting.

Having both options, plus individual exporting options n each record, it allows for fine tuning the automatic OAI harvisting.

The exporting class should be updated to make use of export to public. 

This feature differs from "Production Ready" in that production ready allows staff to enter data into the form. Allow release to public is when the form is ready for exporting as public consumption.