### PR TITLE
Update the download all files location

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -6,6 +6,7 @@ convertedPath=/home/mfcs.lib.wvu.edu/data/exports
 mfcstmp=/home/mfcs.lib.wvu.edu/data/working/tmp
 nfsexport=/home/mfcs.lib.wvu.edu/data/nfs-exports/mfcs-exports
 exportControlTemplate=/home/mfcs.lib.wvu.edu/public_html/includes/templates/export_control_file.yaml
+mfcsDownloadAllDir=/home/mfcs.lib.wvu.edu/exports/download-all
 
 siteRoot=/
 pageTitle=Metadata Form Creation System

--- a/public_html/dataView/allfiles.php
+++ b/public_html/dataView/allfiles.php
@@ -59,7 +59,7 @@ try {
 		}
 
 		$files           = implode(" ",$files);
-		$destinationFile = sprintf("%s/%s.%s",(mfcs::config('mfcsDownloadAllDir'),time(),$type);
+		$destinationFile = sprintf("%s/%s.%s",mfcs::config('mfcsDownloadAllDir'),time(),$type);
 
 		if ($type == "zip") {
 			$cmdLine = sprintf("zip -j %s %s",$destinationFile,$files);

--- a/public_html/dataView/allfiles.php
+++ b/public_html/dataView/allfiles.php
@@ -41,6 +41,8 @@ try {
 	}
 
 	//determine the field name
+	// FIXME: this will only grab the LAST file field, if a form has Multiple
+	// file fields this will not download all of the files.
 	$field_name = "";
 	$form = forms::get($object['formID']);
 	foreach ($form['fields'] as $field) {
@@ -53,13 +55,11 @@ try {
 		$files = array();
 
 		foreach ($object['data'][$field_name]['files']['archive'] as $file) {
-
-			$files[] = sprintf("%s",$file['name']);
-
+			$files[] = $file['name'];
 		}
 
 		$files           = implode(" ",$files);
-		$destinationFile = sys_get_temp_dir()."/".time().".".$type;
+		$destinationFile = sprintf("%s/%s.%s",(mfcs::config('mfcsDownloadAllDir'),time(),$type);
 
 		if ($type == "zip") {
 			$cmdLine = sprintf("zip -j %s %s",$destinationFile,$files);
@@ -86,31 +86,12 @@ try {
 		header("Cache-Control: public");
 		header("Content-Description: File Transfer");
 		header("Content-type: application/zip");
-		header("Content-Disposition: attachment; filename=\"".$object['idno'].".".$type."\"");
+		header(sprintf('Content-Disposition: attachment; filename="%s.%s"',$object['idno'],$type));
 		header("Content-Transfer-Encoding: binary");
-		header("Content-Length: ".filesize($destinationFile));
-		ob_end_clean(); 
+		header(sprintf("Content-Length: %s",filesize($destinationFile)));
 		@readfile($destinationFile);
 
-
-		// header(sprintf("Content-Disposition: attachment; filename='%s.%s'",
-		// 	$object['idno'],
-		// 	$type
-		// 	)
-		// );
-		// header("Content-Type: application/octet-stream");
-
-		// ob_end_clean(); 
-		// flush(); 
-
-		// print file_get_contents($destinationFile);
-
 		unlink($destinationFile);
-
-		// print "<pre>";
-		// var_dump($cmdLine);
-		// print "</pre>";
-
 	}
 	else {
 		throw new Exception("No digital Files");


### PR DESCRIPTION
On large downloads, the /tmp directory was filling up and causing the download to be 0 bytes. This addresses that issue. 

This is to address the issue in ticket: https://systems.lib.wvu.edu/helpdesk/viewTicket/?id=14773

THis has been tested on MFCS dev with record P31 and P3001. P31 worked previously and continues to work with this update. P3001 was too large to download previously, and now works correctly. 