### PR TITLE
publicRelease update

### DIFF
--- a/public_html/dataEntry/revisions/index.php
+++ b/public_html/dataEntry/revisions/index.php
@@ -35,7 +35,7 @@ try{
 			throw new Exception('Could not load revision.');
 		}
 
-		if (objects::update($engine->cleanGet['MYSQL']['objectID'],$revision['formID'],(decodeFields($revision['data'])),$revision['metadata'],$revision['parentID']) !== FALSE) {
+		if (objects::update($engine->cleanGet['MYSQL']['objectID'],$revision['formID'],(decodeFields($revision['data'])),$revision['metadata'],$revision['parentID'], NULL, $revision['publicRelease']) !== FALSE) {
 			// Reload the object - To refresh the data
 			$object = objects::get($objectID,TRUE);
 		}

--- a/public_html/includes/classes/forms.php
+++ b/public_html/includes/classes/forms.php
@@ -1377,7 +1377,7 @@ class forms {
 				// Check to see if the objects data has changed. if it has, update it.
 				if (encodeFields($values) != $object['data']) {
 
-					if (objects::update($object['ID'],$formID,$values,$form['metadata']) === FALSE) {
+					if (objects::update($object['ID'],$formID,$values,$form['metadata'],$object['parentID'],null,$object['publicRelease']) === FALSE) {
 						$engine->openDB->transRollback();
 						$engine->openDB->transEnd();
 
@@ -1495,7 +1495,7 @@ class forms {
 
 		if (isset($engine->cleanPost['RAW']['publicReleaseObj'])) {
 			$publicReleaseObj = strtolower($engine->cleanPost['RAW']['publicReleaseObj']) == "no" ? 0 : 1;
-		} else { 
+		} else {
 			// create the public release object as a default
 			$publicReleaseObj = 1;
 		}


### PR DESCRIPTION
added the publicRelease value to the list of variables when objects::update is being called. The current value was being lost and all objects were defaulting to 0 even if this was previously set.