### PR TITLE
Fix to correct filename issue

### DIFF
--- a/public_html/includes/classes/files.php
+++ b/public_html/includes/classes/files.php
@@ -1368,7 +1368,7 @@ class files {
         }
 
 		$return = array(
-			'name'   => $name.'.'.$format,
+			'name'   => $name.$format,
 			'path'   => self::getSaveDir($assetsID,'video',FALSE),
 			'size'   => filesize(self::getSaveDir($assetsID,'video').$name.$format),
 			'type'   => self::getMimeType(self::getSaveDir($assetsID,'video').$name.$format),


### PR DESCRIPTION
In returning the array of the converted object the name contained an extra  ".". This was preventing the export from finding the files correctly. 

One file has been modified.
 public_html/includes/classes/files.php 